### PR TITLE
Use serde_bytes for massive speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "ipc-channel 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -539,6 +540,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +754,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2"
 [dev-dependencies]
 criterion = "0.3"
 bincode = { version="1" }
+serde_bytes = "0.11"
 
 [[bench]]
 name = "ipc_bytes_channel"

--- a/benches/bincode.rs
+++ b/benches/bincode.rs
@@ -6,6 +6,7 @@ use serde::{Serialize, Deserialize};
 struct Message {
 	//pub topic: String,
 	pub topic: u32,
+        #[serde(with = "serde_bytes")]
 	pub data: Vec<u8>
 }
 

--- a/benches/ipc_channel.rs
+++ b/benches/ipc_channel.rs
@@ -8,6 +8,7 @@ use serde::{Serialize, Deserialize};
 struct Message {
 	//pub topic: String,
 	pub topic: u32,
+        #[serde(with = "serde_bytes")]
 	pub data: Vec<u8>
 }
 


### PR DESCRIPTION
```
bincode_encode/1024     time:   [66.972 ns 67.799 ns 68.733 ns]
                        thrpt:  [13.875 GiB/s 14.066 GiB/s 14.240 GiB/s]
                 change:
                        time:   [-99.249% -99.232% -99.214%] (p = 0.00 < 0.05)
                        thrpt:  [+12621% +12928% +13221%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
bincode_encode/10240    time:   [213.43 ns 216.79 ns 220.68 ns]
                        thrpt:  [43.216 GiB/s 43.990 GiB/s 44.684 GiB/s]
                 change:
                        time:   [-99.784% -99.776% -99.768%] (p = 0.00 < 0.05)
                        thrpt:  [+42992% +44464% +46131%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
bincode_encode/51200    time:   [1.2698 us 1.2858 us 1.3032 us]
                        thrpt:  [36.589 GiB/s 37.083 GiB/s 37.551 GiB/s]
                 change:
                        time:   [-99.719% -99.715% -99.710%] (p = 0.00 < 0.05)
                        thrpt:  [+34410% +34927% +35483%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
bincode_encode/102400   time:   [2.6552 us 2.6984 us 2.7459 us]
                        thrpt:  [34.731 GiB/s 35.342 GiB/s 35.917 GiB/s]
                 change:
                        time:   [-99.739% -99.729% -99.720%] (p = 0.00 < 0.05)
                        thrpt:  [+35576% +36827% +38217%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

bincode_decode/1024     time:   [49.542 ns 49.994 ns 50.474 ns]
                        thrpt:  [18.895 GiB/s 19.076 GiB/s 19.250 GiB/s]
                 change:
                        time:   [-97.834% -97.759% -97.683%] (p = 0.00 < 0.05)
                        thrpt:  [+4215.8% +4362.7% +4517.8%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
bincode_decode/10240    time:   [180.23 ns 186.57 ns 194.88 ns]
                        thrpt:  [48.936 GiB/s 51.117 GiB/s 52.914 GiB/s]
                 change:
                        time:   [-99.007% -98.987% -98.963%] (p = 0.00 < 0.05)
                        thrpt:  [+9544.6% +9768.3% +9972.0%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
bincode_decode/51200    time:   [1.3707 us 1.4043 us 1.4415 us]
                        thrpt:  [33.079 GiB/s 33.956 GiB/s 34.788 GiB/s]
                 change:
                        time:   [-98.527% -98.499% -98.472%] (p = 0.00 < 0.05)
                        thrpt:  [+6443.3% +6563.4% +6687.5%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
bincode_decode/102400   time:   [2.8500 us 2.8983 us 2.9514 us]
                        thrpt:  [32.312 GiB/s 32.905 GiB/s 33.462 GiB/s]
                 change:
                        time:   [-98.430% -98.395% -98.358%] (p = 0.00 < 0.05)
                        thrpt:  [+5991.4% +6128.9% +6267.5%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

See the readme for [serde_bytes](https://crates.io/crates/serde_bytes) for some explanation.